### PR TITLE
fix: Do not log passwords when logging db urls

### DIFF
--- a/aio_databases/backends/__init__.py
+++ b/aio_databases/backends/__init__.py
@@ -9,6 +9,7 @@ from urllib.parse import SplitResult, parse_qsl
 
 from aio_databases.log import logger as base_logger
 from aio_databases.types import TVConnection
+from aio_databases.url import redact_url
 
 if TYPE_CHECKING:
     import logging
@@ -252,10 +253,10 @@ class ABCDatabaseBackend(abc.ABC, Generic[TVConnection]):
         return conn
 
     async def connect(self) -> None:
-        self.logger.info("Connecting to %s", self.url)
+        self.logger.info("Connecting to %s", redact_url(self.url).geturl())
 
     async def disconnect(self) -> None:
-        self.logger.info("Disconnecting from %s", self.url)
+        self.logger.info("Disconnecting from %s", redact_url(self.url).geturl())
 
     @abc.abstractmethod
     async def _acquire(self) -> TVConnection:

--- a/aio_databases/url.py
+++ b/aio_databases/url.py
@@ -1,0 +1,11 @@
+from urllib.parse import SplitResult
+
+
+def redact_url(parsed_url: SplitResult) -> SplitResult:
+    """Redact password from URL for representation."""
+    if parsed_url.password:
+        hostname_port = parsed_url.hostname or ""
+        if parsed_url.port:
+            hostname_port += f":{parsed_url.port}"
+        return parsed_url._replace(netloc=(parsed_url.username or "") + f":***@{hostname_port}")
+    return parsed_url


### PR DESCRIPTION
This prevents the password from being leaked in the log files, especially since we log these at the INFO level.